### PR TITLE
Remove unnecessary media query

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -146,13 +146,10 @@ html, body {
   font-size: 2rem;
   color: #454851;
   z-index: 3;
-  /* ----------- Laptop Screens ----------- */
 }
-@media screen and (min-device-width: 1200px) and (max-device-width: 1600px) {
-  .arrow:hover {
-    cursor: pointer;
-    color: #686d7a;
-  }
+.arrow:hover {
+  cursor: pointer;
+  color: #686d7a;
 }
 
 /* ==  Project Section  == */


### PR DESCRIPTION
The media query seems to be an odd choice, limiting the hover style to laptop screens only, instead of being applied across the board.

This pull request fixes that, but feel free to reject if it doesn't comply with what you tried to accomplish.
